### PR TITLE
[ISSUE-61] Retrieve the settings on the Settings page

### DIFF
--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -42,7 +42,11 @@
       <div class="repositories-list">
         <% repos.each do |repo| %>
           <div class="repository">
-            <%= check_box_tag('repo[]', repo.name, false, { id: repo.name }) %>
+            <% if current_user.settings['repos'].include? repo.name %>
+              <%= check_box_tag('repo[]', repo.name, true, { id: repo.name }) %>
+            <% else %>
+              <%= check_box_tag('repo[]', repo.name, false, { id: repo.name }) %>
+            <% end %>
             <%= label_tag(repo.name, repo.name) %>
             <% if repo.is_private %>
               <i class="fas fa-lock"></i>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Retrieve the user settings from the users table.
Display the checkbox as `checked` status when a repo name matches one from the GitHub repositories.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #61 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Retrieving user specific settings so that a user has is preferences already selected on the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
