### PR TITLE
[ISSUE-70] Give a background to selected repositories

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,11 +1,4 @@
 <div class="dashboard-container">
-  <section name="dashboard">
-    <header>
-      <h2>Dashboard</h2>
-      <hr class="separator" />
-    </header>
-  </section>
-
   <section name="pull requests">
     <div class="pr-list">
       <% pull_requests&.each do |pr| %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -2,7 +2,6 @@
   <section name="settings">
     <header>
       <h2>Settings</h2>
-      <hr class="separator" />
     </header>
   </section>
 
@@ -13,10 +12,6 @@
   </div>
 
   <section name="organizations">
-    <header>
-      <h3 class="setttings-title">ORGANIZATIONS</h3>
-    </header>
-
     <div class="organizations-list">
       <div class="organization">
         <div class="organization-avatar"><img src="<%= viewer.avatar_url  %>" alt="<%= viewer.name %>"></div>
@@ -41,11 +36,12 @@
     <%= form_with(url: "/#{current_user&.nickname}/settings/save", method: :post, data: { 'action': 'ajax:success->settings#onSuccess ajax:before->settings#onSubmit ajax:error->settings#onError' }) do |f| %>
       <div class="repositories-list">
         <% repos.each do |repo| %>
-          <div class="repository">
             <% if current_user.settings['repos'].include? repo.name_with_owner %>
-              <%= check_box_tag('repo[]', repo.name_with_owner, true, { id: repo.name_with_owner }) %>
+          <div class="repository repository-checked">
+              <%= check_box_tag('repo[]', repo.name_with_owner, true, { id: repo.name_with_owner, data: { 'action': "click->settings#toggleRepository" } }) %>
             <% else %>
-              <%= check_box_tag('repo[]', repo.name_with_owner, false, { id: repo.name_with_owner }) %>
+          <div class="repository">
+            <%= check_box_tag('repo[]', repo.name_with_owner, false, { id: repo.name_with_owner, data: { 'action': "click->settings#toggleRepository" } }) %>
             <% end %>
             <%= label_tag(repo.name_with_owner, repo.name_with_owner) %>
             <% if repo.is_private %>
@@ -55,10 +51,9 @@
         <% end %>
       </div>
       <div class="settings-actions space-top">
-        <%= link_to 'Cancel', root_url, class: 'settings-cancel space-right-1' %>
-        <%= f.button('Save', type: :submit, class: 'settings-save-btn') do %>
+        <%= f.button('Update settings', type: :submit, class: 'settings-save-btn') do %>
           <i class="fas fa-circle-notch fa-spin js-loading-indicator hidden"></i>
-          Save
+          Update settings
         <% end %>
       </div>
     <% end %>

--- a/app/webpacker/controllers/settings_controller.js
+++ b/app/webpacker/controllers/settings_controller.js
@@ -5,7 +5,6 @@ export default class extends Controller {
 
     onSuccess(event) {
         event.preventDefault();
-        console.log('OnSuccess fired');
         let [data, status, xhr] = event.detail;
         document.querySelector('.js-loading-indicator').classList.toggle('hidden');
         document.querySelector('.alert-header').innerHTML = '<i class="fas fa-check-circle space-right"></i>Marvellous!';
@@ -40,6 +39,14 @@ export default class extends Controller {
     disconnect() {
         if (this.timer) {
             clearTimer(this.timer);
+        }
+    }
+
+    toggleRepository(event) {
+        if(event.target.checked) {
+            event.srcElement.parentElement.classList.add('repository-checked');
+        } else {
+            event.srcElement.parentElement.classList.remove('repository-checked');
         }
     }
 }

--- a/app/webpacker/stylesheets/settings.scss
+++ b/app/webpacker/stylesheets/settings.scss
@@ -69,8 +69,15 @@
   box-shadow: 0 2px 6px 0 rgba(0, 0%, 0%, 0.2);
 }
 
+.repository-checked {
+  background-color: #66da96;
+}
+
 .fa-lock {
-  color: #dbab09;
+  color: #ffffff;
+  background-color: #0c0c0d;
+  padding: .5em;
+  border-radius: 50%;
 }
 
 .fa-check-circle {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a background color green to selected repositories on the Settings page.
Little UI design changes on the settings page and dashboard.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #70 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better visual hints of what is selected or not, relying on the status of the checkbox is not enough to see at first glance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/64512858-99230c00-d2e7-11e9-8014-3d774735e8d9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
