### PR TITLE
[ISSUE-69] Remove default PR status when there is no status

### DIFF
--- a/app/webpacker/stylesheets/dashboard.scss
+++ b/app/webpacker/stylesheets/dashboard.scss
@@ -87,7 +87,7 @@
 }
 
 .pr-card-status-default {
-  background-color: #ffffff;
+  display: none;
 }
 
 .pr-card-status-pending {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove the Status of pull request if there is no CI used on the project.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #69 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It looks better to not display a blank status on the PR if there is no CI configured.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/64522273-ed36ec00-d2f9-11e9-80ce-e3a3589cf201.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
