### PR TITLE
[ISSUE-65] Check the Pull request status asynchronously

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -73,4 +73,19 @@ class DashboardController < ApplicationController
       pull_requests: pull_requests
     }
   end
+
+  def refresh
+    pull_requests = []
+
+    unless user_repositories.empty?
+      results = Tentacles::Client.query(
+        PullRequestsQuery,
+        variables: { queryString: build_query_string(user_repositories), number_or_prs: 100, number_or_labels: 10 },
+        context: client_context
+      )
+      pull_requests = results&.data&.search&.edges
+    end
+
+    render json: { pull_requests: pull_requests }, content_type: 'application/json', status: :ok
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<div class="dashboard-container">
+<div class="dashboard-container" data-controller="dashboard">
   <section name="pull requests">
     <div class="pr-list">
       <% pull_requests&.each do |pr| %>
@@ -27,13 +27,13 @@
               </div><!-- end of pr-card-number -->
               <% node = pr&.node&.commits&.nodes.first %>
               <% if node&.commit&.status&.state == 'SUCCESS' %>
-                <div class="pr-card-status pr-card-status-success" aria-label="Pull request status success">&nbsp;</div>
+                <div class="pr-card-status pr-card-status-success" aria-label="Pull request status success" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
               <% elsif node&.commit&.status&.state == 'FAILURE' %>
-                <div class="pr-card-status pr-card-status-failure" aria-label="Pull request status failure">&nbsp;</div>
+                <div class="pr-card-status pr-card-status-failure" aria-label="Pull request status failure" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
               <% elsif node&.commit&.status&.state == 'PENDING' %>
-                <div class="pr-card-status pr-card-status-pending" aria-label="Pull request status pending">&nbsp;</div>
+                <div class="pr-card-status pr-card-status-pending" aria-label="Pull request status pending" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
               <% else %>
-                <div class="pr-card-status pr-card-status-default" aria-label="No pull request status">&nbsp;</div>
+                <div class="pr-card-status pr-card-status-default" aria-label="No pull request status" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
               <% end %>
 
             </div><!-- end of pr-card-status -->

--- a/app/webpacker/controllers/dashboard_controller.js
+++ b/app/webpacker/controllers/dashboard_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    static targets = ['commit'];
+
+    connect() {
+        this.startRefreshing();
+    }
+
+    disconnect() {
+        this.stopRefreshing()
+    }
+
+    refreshPullRequests() {
+        fetch('/dashboard/refresh')
+            .then((resp) => resp.json())
+            .then(function(response) {
+                response.pull_requests.forEach(function(element) {
+                    var prStatus = document.getElementById(element.data.node.number);
+                    if (prStatus) {
+                        var commit = element.data.node.commits.nodes[0].commit;
+                        if(commit.status) {
+                            var state = commit.status.state;
+                            prStatus.classList.remove('pr-card-status-pending');
+                            prStatus.classList.add(`pr-card-status-${state.toLowerCase()}`);
+                        }
+                    }
+                });
+            });
+    }
+
+    startRefreshing() {
+        // Use 1 800 000 for 30 min
+        this.refreshTimer = setInterval(() => {
+            this.commitTargets.forEach((element, index) => {
+                element.classList.remove('pr-card-status-success', 'pr-card-status-failure', 'pr-card-status-pending');
+                element.classList.add('pr-card-status-pending');
+
+            });
+            this.refreshPullRequests();
+        }, 30000) // Every 30 seconds
+    }
+
+    stopRefreshing() {
+        if (this.refreshTimer) {
+            clearInterval(this.refreshTimer)
+        }
+    }
+}
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'dashboard#index'
+  get '/dashboard/refresh', to: 'dashboard#refresh', as: :refresh
   get '/auth/user', to: 'sessions#new', as: :signin
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/signout', to: 'sessions#destroy', as: :signout


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a periodic check to read the Pull Requests statuses asynchronously.
Add methods to update the statuses on the UI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #65 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows us to see the Pull Requests statuses in near real-time by checking periodically (for the moment every 30 seconds).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
