### PR TITLE
[ISSUE-80] Display Pull Request seniority

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,6 +5,7 @@
 #
 class DashboardController < ApplicationController
   include DashboardHelper
+  include ActionView::Helpers::DateHelper
   layout 'default'
   before_action :authenticate_user!
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -2,47 +2,59 @@
   <section name="pull requests">
     <div class="dashboard__cards">
       <% pull_requests&.each do |pr| %>
-        <div class="pr-card">
+        <% pr_age = 'pr-card__age--normal' %>
+        <% pr_date = Time.parse(pr.node.created_at).to_date %>
+        <% now = Time.now.to_date %>
+        <% number_of_days = (now - pr_date).to_i %>
+        <% if number_of_days >= 180 %>
+            <% pr_age = 'pr-card__age--critical' %>
+          <% elsif number_of_days >= 80  %>
+            <% pr_age = 'pr-card__age--important' %>
+          <% elsif number_of_days >= 16 %>
+            <% pr_age = 'pr-card__age--high' %>
+          <% elsif number_of_days >= 10 %>
+            <% pr_age = 'pr-card__age--medium' %>
+          <% end %>
+          <div class="pr-card <%= pr_age %>">
 
-          <div class="pr-card__header">
+            <div class="pr-card__header">
+              <div class="pr-card__state">
+                <div class="pr-card__number">
+                  <a href="<%= pr.node.url %>">#<%=  pr.node.number %></a>
+                </div><!-- end of pr-card-number -->
+                <% node = pr&.node&.commits&.nodes.first %>
+                <% if node&.commit&.status&.state == 'SUCCESS' %>
+                  <div class="pr-card__status pr-card__status--success" aria-label="Pull request status success" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+                <% elsif node&.commit&.status&.state == 'FAILURE' %>
+                  <div class="pr-card__status pr-card__status--failure" aria-label="Pull request status failure" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+                <% elsif node&.commit&.status&.state == 'PENDING' %>
+                  <div class="pr-card-status pr-card__status--pending" aria-label="Pull request status pending" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+                <% else %>
+                  <div class="pr-card__status pr-card__status--default" aria-label="No pull request status" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+                <% end %>
+              </div><!-- end of pr-card-state -->
 
-            <div class="pr-card__state">
-              <div class="pr-card__number">
-                <a href="<%= pr.node.url %>">#<%=  pr.node.number %></a>
-              </div><!-- end of pr-card-number -->
-              <% node = pr&.node&.commits&.nodes.first %>
-              <% if node&.commit&.status&.state == 'SUCCESS' %>
-                <div class="pr-card__status pr-card__status--success" aria-label="Pull request status success" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
-              <% elsif node&.commit&.status&.state == 'FAILURE' %>
-                <div class="pr-card__status pr-card__status--failure" aria-label="Pull request status failure" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
-              <% elsif node&.commit&.status&.state == 'PENDING' %>
-                <div class="pr-card-status pr-card__status--pending" aria-label="Pull request status pending" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+              <div class="pr-card__base">
+                based on <strong><%=  pr.node.base_ref_name %></strong>
+              </div>
+            </div><!-- end of pr-card header -->
+
+            <div class="pr-card__org">
+              <%= pr.node.base_repository.name_with_owner %>
+            </div><!-- end of pr-card organization -->
+
+            <div class="pr-card__title">
+              <% if pr.node.title&.size > 80 %>
+                <%=  pr.node.title[0..76] %>...
               <% else %>
-                <div class="pr-card__status pr-card__status--default" aria-label="No pull request status" id="<%= pr.node.number %>" data-target="dashboard.commit">&nbsp;</div>
+                <%=  pr.node.title %>
               <% end %>
-            </div><!-- end of pr-card-state -->
+            </div><!-- end of pr-card title -->
 
-            <div class="pr-card__base">
-              based on <strong><%=  pr.node.base_ref_name %></strong>
-            </div>
-          </div><!-- end of pr-card header -->
-
-          <div class="pr-card__org">
-            <%= pr.node.base_repository.name_with_owner %>
-          </div>
-
-          <div class="pr-card__title">
-            <% if pr.node.title&.size > 60 %>
-              <%=  pr.node.title[0..56] %>...
-            <% else %>
-              <%=  pr.node.title %>
-            <% end %>
-          </div><!-- end of pr-card title -->
-
-          <div class="pr-card__author">
-            <span class="pr-card__author--name">opened by&nbsp;<strong><%= pr.node.author.login %></strong></span>
-            <img src="<%= pr.node.author.avatar_url %>" alt="<%= pr.node.author.login %>" class="pr-card__author--avatar">
-          </div><!-- end of pr-card title -->
+            <div class="pr-card__author">
+              <span class="pr-card__author--name">opened <%= distance_of_time_in_words_to_now(pr.node.created_at) %>&nbsp;ago&nbsp;by&nbsp;<strong><%= pr.node.author.login %></strong></span>
+              <img src="<%= pr.node.author.avatar_url %>" alt="<%= pr.node.author.login %>" class="pr-card__author--avatar">
+            </div><!-- end of pr-card author -->
 
         </div><!-- end of pr-card -->
       <% end %>

--- a/app/webpacker/stylesheets/dashboard.scss
+++ b/app/webpacker/stylesheets/dashboard.scss
@@ -19,10 +19,30 @@
   padding: .5em;
   margin: .25em;
   width: 320px;
-  height: 140px;
+  height: 150px;
   position:relative;
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, .2);
   border-radius: 0.25em;
+}
+
+.pr-card__age--normal {
+  border-top: 0;
+}
+
+.pr-card__age--critical {
+  border-top: .3em solid #d12938;
+}
+
+.pr-card__age--important {
+  border-top: .3em solid rgba(209, 41, 55, 0.8);
+}
+
+.pr-card__age--high {
+  border-top: .3em solid rgba(209, 41, 55, 0.6);
+}
+
+.pr-card__age--medium {
+  border-top: .3em solid rgba(209, 41, 55, 0.4);
 }
 
 .pr-card__org {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add an indicator on the top border of the dashboard cards to display the seniority of a PR.
Add the time of the opened PR as a number of time in words (ex: 3 days ago).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #80 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better spotting of the oldest PR to help speed the review process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/65164535-642c5d00-da3d-11e9-8333-c37c7ef5b5d8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
