### PR TITLE
[ISSUE-85] Repositories appears two times on the settings

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,7 +16,7 @@ class SettingsController < ApplicationController
         login
         avatarUrl
         url
-        repositories(last: $last_repos) {
+        repositories(last: $last_repos, affiliations:OWNER) {
           totalCount
           nodes {
             name

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -48,7 +48,7 @@
           <div class="repository">
             <%= check_box_tag('repo[]', repo.name_with_owner, false, { class: 'repo', id: repo.name_with_owner, data: { 'action': "click->settings#toggleRepository" } }) %>
             <% end %>
-            <label for="<%= repo.name_with_owner %>" class="repository-label"%><%= repo.name_with_owner %></label>
+            <label for="<%= repo.name_with_owner %>" class="repository-label"><%= repo.name_with_owner %></label>
             <% if repo.is_private %>
               <i class="fas fa-lock"></i>
             <% end %>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a filter on the GraphQL querry to retrieve repositories only owned by the current user.
Fix a markup issue for the repositories labels.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #85 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some repositories were appearing tow times, one time for the repos of the current user and one time for the organization the current user belongs to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Chrome and Firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
