### PR TITLE
[ISSUE-205] Fix postgres service is unhealthy error in Github Action

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -10,6 +10,10 @@ jobs:
     services:
       postgres:
         image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tentacles_test
         ports: ['5432:5432']
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
@@ -25,6 +29,7 @@ jobs:
         PGUSER: postgres
         RAILS_ENV: test
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        TENTACLES_DEV_DATABASE_PASSWORD: postgres
       run: |
         sudo apt-get -yqq install libpq-dev
         gem install bundler


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes the PostgreSQL is unhealthy error popping up in the GitHub Action lately

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #205 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Seems like the service for the PostgreSQL database needs the credentials in the `env` section now, otherwise it is failing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in GitHub Action.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, Github templates,..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
